### PR TITLE
Add multi-subject tutor modes

### DIFF
--- a/pages/api/lesson.js
+++ b/pages/api/lesson.js
@@ -16,7 +16,7 @@ export default async function handler(req, res) {
 
   console.log('Request body:', JSON.stringify(req.body, null, 2));
 
-  const { grade, topic, history, reveal } = req.body;
+  const { grade, subject, topic, history, reveal } = req.body;
   // Validate payload
   if (!grade || !topic || !Array.isArray(history)) {
     return res.status(400).json({ error: 'Invalid request payload' });
@@ -32,7 +32,7 @@ export default async function handler(req, res) {
     const revealMessages = [
       {
         role: 'system',
-        content: `You are a detailed, explanatory math tutor for ${grade}th-graders. Respond with JSON only, no extra text.`
+        content: `You are a detailed, explanatory ${subject} tutor for ${grade}th-graders. Respond with JSON only, no extra text. Focus on teaching the core concepts clearly and ensure the correctness of the solutions.`
       },
       {
         role: 'user',
@@ -80,7 +80,8 @@ export default async function handler(req, res) {
       {
         role: 'system',
         content: [
-          `You are a playful, engaging math tutor for ${grade}th-graders.`,
+          `You are a playful, engaging ${subject} tutor for ${grade}th-graders.`,
+          `Teach the core concepts in the most intuitive way for their age and value correctness greatly.`,
           `Make explanations fun—use characters, stories, or mini-scenes.`,
           `Always respond with JSON only; no extra text.`
         ].join(' ')
@@ -130,9 +131,10 @@ export default async function handler(req, res) {
       {
         role: 'system',
         content: [
-          `You are a playful, kid-friendly ${grade}th-grade tutor.`,
+          `You are a playful, kid-friendly ${subject} tutor for ${grade}th-graders.`,
+          `Teach core concepts intuitively and value correctness of answers above all.`,
           `Based on the student’s last answer and the full question context (prompt and explanation), infer the likely mistake and give a diagnostic hint.`,
-          `For incorrect answers, your NEXT QUESTION must be self-contained: repeat the entire question object including its explanation. Carefully check for correctness of answer, that is paramount.`,
+          `For incorrect answers, your NEXT QUESTION must be self-contained: repeat the entire question object including its explanation.`,
           `Always respond with JSON only; no extra text.`
         ].join(' ')
       },
@@ -195,7 +197,8 @@ export default async function handler(req, res) {
         {
           role: 'system',
           content: [
-            `You are a playful, engaging math tutor for ${grade}th-graders.`,
+            `You are a playful, engaging ${subject} tutor for ${grade}th-graders.`,
+            `Teach core concepts intuitively and value correctness greatly.`,
             `Make explanations fun—use characters, stories, or mini-scenes.`,
             `Always respond with JSON only; no extra text.`
           ].join(' ')

--- a/pages/api/topics.js
+++ b/pages/api/topics.js
@@ -7,15 +7,22 @@ export default async function handler(req, res) {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end('Method Not Allowed');
   }
-  const { grade } = req.query;
-  console.log('/api/topics called with grade:', grade);
+  const { grade, subject } = req.query;
+  console.log('/api/topics called with grade:', grade, 'subject:', subject);
 
   try {
+    const plannerRole = {
+      math: 'You are an elementary math curriculum planner.',
+      science: 'You are an elementary science curriculum planner.',
+      spanish: 'You are a beginner Spanish language curriculum planner.',
+      hindi: 'You are a beginner Hindi language curriculum planner.'
+    }[subject] || 'You are an elementary tutor.';
+
     const response = await openai.chat.completions.create({
       model: MODEL,
       messages: [
-        { role: 'system', content: 'You are an elementary math curriculum planner.' },
-        { role: 'user', content: `List the basic topics appropriate for grade ${grade} math as a JSON array of strings. Always respond with JSON only; no extra text. ` }
+        { role: 'system', content: plannerRole },
+        { role: 'user', content: `List the basic topics appropriate for grade ${grade} ${subject} as a JSON array of strings. Always respond with JSON only; no extra text.` }
       ],
       temperature: TEMPERATURE,
     });

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 export default function Home() {
+  const [subject, setSubject] = useState('');
   const [grade, setGrade] = useState('');
   const [topics, setTopics] = useState([]);
   const [selectedTopic, setSelectedTopic] = useState('');
@@ -12,7 +13,13 @@ export default function Home() {
   const [answerInput, setAnswerInput] = useState('');
   const [attempts, setAttempts] = useState(0);
 
-  // 1) Fetch topics for a grade
+  // 1) Subject selection
+  const handleSubjectSelect = (subj) => {
+    console.log('Subject selected:', subj);
+    setSubject(subj);
+  };
+
+  // 2) Fetch topics for a grade
   const handleGradeSelect = async (e) => {
     const g = e.target.value;
     console.log('Grade selected:', g);
@@ -21,7 +28,7 @@ export default function Home() {
     setContent(null);
     setTopicsLoading(true);
     try {
-      const res = await fetch(`/api/topics?grade=${g}`);
+      const res = await fetch(`/api/topics?grade=${g}&subject=${subject}`);
       const data = await res.json();
       console.log('Topics API response:', data);
       setTopics(data.topics || []);
@@ -33,7 +40,7 @@ export default function Home() {
     }
   };
 
-  // 2) Start lesson on a topic
+  // 3) Start lesson on a topic
   const handleTopicSelect = async (topic) => {
     console.log('Topic selected:', topic);
     setSelectedTopic(topic);
@@ -45,7 +52,7 @@ export default function Home() {
       const res = await fetch('/api/lesson', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ grade, topic, history: [] }),
+        body: JSON.stringify({ grade, subject, topic, history: [] }),
       });
       const data = await res.json();
       console.log('Initial lesson content:', data);
@@ -84,7 +91,7 @@ export default function Home() {
       const res = await fetch('/api/lesson', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ grade, topic: selectedTopic, history: newHistory }),
+        body: JSON.stringify({ grade, subject, topic: selectedTopic, history: newHistory }),
       });
       const data = await res.json();
       console.log('Lesson follow-up content:', data);
@@ -109,7 +116,7 @@ export default function Home() {
       const res = await fetch('/api/lesson', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ grade, topic: selectedTopic, history, reveal: true }),
+        body: JSON.stringify({ grade, subject, topic: selectedTopic, history, reveal: true }),
       });
       const data = await res.json();
       console.log('Reveal content:', data);
@@ -124,7 +131,29 @@ export default function Home() {
 
   // --- UI branches ---
 
-  // A) Grade picker
+  // A) Subject picker
+  if (!subject) {
+    return (
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
+        <div className="bg-white rounded-lg shadow-md p-6 w-full max-w-md space-y-4">
+          <h1 className="text-3xl font-bold mb-6 text-center">Select Subject</h1>
+          <div className="grid grid-cols-2 gap-4">
+            {['math','science','spanish','hindi'].map(s => (
+              <button
+                key={s}
+                onClick={() => handleSubjectSelect(s)}
+                className="bg-blue-500 hover:bg-blue-600 text-white p-3 rounded"
+              >
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // B) Grade picker
   if (!grade) {
     return (
       <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
@@ -140,6 +169,12 @@ export default function Home() {
               <option key={g} value={g}>{g}th Grade</option>
             ))}
           </select>
+          <button
+            onClick={() => { setSubject(''); setGrade(''); }}
+            className="mt-4 text-blue-500 hover:underline"
+          >
+            ← Back to Subject
+          </button>
         </div>
       </div>
     );
@@ -162,9 +197,15 @@ export default function Home() {
         {/* Back to grade selection */}
         <button
           onClick={() => { setGrade(''); setTopics([]); }}
-          className="mb-4 text-blue-500 hover:underline"
+          className="mb-2 text-blue-500 hover:underline"
         >
           ← Back to Grade
+        </button>
+        <button
+          onClick={() => { setSubject(''); setGrade(''); setTopics([]); }}
+          className="mb-4 text-blue-500 hover:underline ml-2"
+        >
+          ← Back to Subject
         </button>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 max-w-3xl mx-auto">
           {topics.map((t,i) => (
@@ -223,7 +264,7 @@ export default function Home() {
           <div className="flex justify-center mb-4">
             <img
               src={questionToShow.imageUrl}
-              alt="Fun math scene"
+              alt="Fun lesson scene"
               className="rounded-xl border-2 border-blue-200 shadow-md max-h-64 object-contain"
             />
           </div>


### PR DESCRIPTION
## Summary
- add subject selector UI and navigation controls
- update topics API to handle subject and grade
- update lesson API prompts for subject awareness and stronger focus on correctness
- display generic alt text for lesson images

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685661e1273483229be64eedcea891bd