### PR TITLE
Allow text question type

### DIFF
--- a/pages/api/lesson.js
+++ b/pages/api/lesson.js
@@ -74,7 +74,7 @@ export default async function handler(req, res) {
           `  "nextQuestion": {`,
           `    "id": "…string…",`,
           `    "prompt": "…string…",`,
-          `    "type": "numeric" or "mcq",`,
+          `    "type": "numeric" or "mcq" or "text",`,
           `    "options"?: ["…string…"],`,
           `    "explanation": "…string…"`,
           `  }`,
@@ -128,7 +128,7 @@ export default async function handler(req, res) {
   "question": {
     "id": "…string…",
     "prompt": "…string…",
-    "type": "numeric"|"mcq",
+    "type": "numeric"|"mcq"|"text",
     "options"?: ["…string…"]
   }
 }`,
@@ -251,7 +251,7 @@ export default async function handler(req, res) {
   "question": {
     "id": "…string…",
     "prompt": "…string…",
-    "type": "numeric"|"mcq",
+    "type": "numeric"|"mcq"|"text",
     "options"?: ["…string…"]
   }
 }`,

--- a/pages/index.js
+++ b/pages/index.js
@@ -416,7 +416,7 @@ export default function Home() {
           <p className="text-xl font-semibold text-blue-800 drop-shadow-sm">{questionToShow.prompt}</p>
         </div>
         <div>
-          {questionToShow.type === 'numeric' ? (
+          {['numeric', 'text'].includes(questionToShow.type) ? (
             <div className="flex space-x-4">
               <input
                 type="text"


### PR DESCRIPTION
## Summary
- add `text` as a question type option in the API prompts
- let numeric and text questions share the same input UI

## Testing
- `node -c pages/api/lesson.js`
- `node -c pages/index.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68576dc905bc8322953629162976ed91